### PR TITLE
Fix Search API Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ query = "grand canyon"
 results = kagi.search(query, limit=10)
 
 for result in results["data"]:
-    print(result["title"])
+    # t = 0 is search result, t = 1 is related searches
+    if result['t'] == 0:
+        print(result["title"])
+    else:
+        print(result["list"])
 ```
 
 #### Example Response


### PR DESCRIPTION
The previous example raised a `KeyError`:

```python
In [7]: query = "grand canyon"
   ...: results = kagi.search(query, limit=10)
   ...: 
   ...: for result in results["data"]:
   ...:     print(result["title"])
   ...: 
```
```
Grand Canyon - National Park Service
Grand Canyon National Park (U.S. National Park Service)
Plan Your Visit - Grand Canyon National Park (U.S. National Park ...
Things To Do - Grand Canyon National Park (U.S. National Park Service)
Grand Canyon - Wikipedia
Grand Canyon National Park - Wikipedia
First-Timer's Guide to the Grand Canyon - Visit Arizona
Grand Canyon (Visitor Guide, Activities & Tours) | Visit Arizona
Grand Canyon Train | Grand Canyon Railway & Hotel
Grand Canyon Lodges
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[7], line 5
      2 results = kagi.search(query, limit=10)
      4 for result in results["data"]:
----> 5     print(result["title"])

KeyError: 'title'
```

This is because t=1 gives related searches in a `list` field, so `title` doesn't exist. I've changes the example to handle this, and to show what the related searches might look like.