### PR TITLE
Add include_references to FastGPT & Fix FastGPT Cache

### DIFF
--- a/kagiapi/api.py
+++ b/kagiapi/api.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Optional, Union, Dict, Literal
 import requests
 from kagiapi.models import (
@@ -70,15 +71,24 @@ class KagiClient:
         response.raise_for_status()
         return response.json()
 
-    def fastgpt(self, query: str, cache: Optional[bool] = True) -> FastGPTResponse:
-        data: Dict[str, Union[int, str]] = {"query": query}
+    def fastgpt(self, query: str, cache: Optional[bool] = True, include_references: bool = True) -> FastGPTResponse:
+        data: Dict[str, Union[int, str, bool]] = {"query": query}
 
         if cache is not None:
-            data["cache"] = "true" if cache else "false"
+            data["cache"] = cache
 
         response = self.session.post(KagiClient.BASE_URL + "/fastgpt", json=data)
         response.raise_for_status()
-        return response.json()
+        
+        result = response.json()
+        
+        if not include_references and "data" in result:
+            if "references" in result["data"]:
+                result["data"]["references"] = []
+            if "output" in result["data"]:
+                result["data"]["output"] = re.sub(r'【\d+】', '', result["data"]["output"])
+        
+        return result
 
     def enrich(self, query: str) -> EnrichResponse:
         params: Dict[str, Union[int, str]] = {"q": query}

--- a/kagiapi/api.py
+++ b/kagiapi/api.py
@@ -73,12 +73,12 @@ class KagiClient:
 
     def fastgpt(self, query: str, cache: Optional[bool] = True, include_references: bool = True) -> FastGPTResponse:
         data: Dict[str, Union[int, str, bool]] = {"query": query}
+        params: Dict[str, str] = {}
 
         if cache is not None:
-            data["cache"] = "true" if cache else "false"
+            params["cache"] = "true" if cache else "false"
 
-
-        response = self.session.post(KagiClient.BASE_URL + "/fastgpt", json=data)
+        response = self.session.post(KagiClient.BASE_URL + "/fastgpt", json=data, params=params)
         response.raise_for_status()
         
         result = response.json()

--- a/kagiapi/api.py
+++ b/kagiapi/api.py
@@ -75,7 +75,8 @@ class KagiClient:
         data: Dict[str, Union[int, str, bool]] = {"query": query}
 
         if cache is not None:
-            data["cache"] = cache
+            data["cache"] = "true" if cache else "false"
+
 
         response = self.session.post(KagiClient.BASE_URL + "/fastgpt", json=data)
         response.raise_for_status()

--- a/kagiapi/models.py
+++ b/kagiapi/models.py
@@ -59,7 +59,7 @@ class FastGPTReference(TypedDict):
 class FastGPTItem(TypedDict):
     output: str
     tokens: int
-    references: List[FastGPTReference]
+    references: NotRequired[List[FastGPTReference]]
 
 
 class FastGPTResponse(TypedDict):


### PR DESCRIPTION
This PR adds the include_references option to FastGPT, when set to False it clears the references array and removes citation markers ( [1] [2]...etc ) from the output for a cleaner look

I've also changed cache to be a url parameter instead of a JSON post to fix 500 errors for FastGPT

![image](https://github.com/user-attachments/assets/498bf013-d6a6-48e8-b2c6-299a913cdb62)
