### PR TITLE
the fastgpt endpoint doesn't take a "cache" argument without a crash

### DIFF
--- a/kagiapi/api.py
+++ b/kagiapi/api.py
@@ -70,11 +70,8 @@ class KagiClient:
         response.raise_for_status()
         return response.json()
 
-    def fastgpt(self, query: str, cache: Optional[bool] = True) -> FastGPTResponse:
+    def fastgpt(self, query: str) -> FastGPTResponse:
         data: Dict[str, Union[int, str]] = {"query": query}
-
-        if cache is not None:
-            data["cache"] = "true" if cache else "false"
 
         response = self.session.post(KagiClient.BASE_URL + "/fastgpt", json=data)
         response.raise_for_status()


### PR DESCRIPTION
I was getting a 500 error every time until I took out this "cache" bit.